### PR TITLE
Issue 35 co2 interactive

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -9,3 +9,4 @@
 | JoeCartonKelly-MO | Joseph Carton-Kelly | Met Office | 2026-04-15 |
 | yg460-cam | Yao Ge | University of Cambridge | 2026-04-17 |
 | theabro | Nathan Luke Abraham | NCAS & University of Cambridge | 2026-03-19 |
+| RobWatersMet | Rob Waters | NCAS & University of Cambridge | 2026-07-06 |

--- a/src/control/core/top_level/ukca_main1-ukca_main1.F90
+++ b/src/control/core/top_level/ukca_main1-ukca_main1.F90
@@ -2369,7 +2369,7 @@ IF (ukca_config%l_ukca_chem) THEN
            atm_h2_mol,                                                         &
            H_plus_3d_arr,                                                      &
            zdryrt, zwetrt, nlev_with_ddep, L_stratosphere,                     &
-           l_firstchem                                                         &
+           co2_interactive, l_firstchem                                        &
            )
 
     ELSE IF (ukca_config%l_ukca_asad_columns) THEN
@@ -2406,7 +2406,7 @@ IF (ukca_config%l_ukca_chem) THEN
            atm_mebr_mol,                                                       &
            atm_h2_mol,                                                         &
            H_plus_3d_arr,                                                      &
-           zdryrt, zwetrt, nlev_with_ddep                                      &
+           zdryrt, zwetrt, nlev_with_ddep, co2_interactive                     &
            )
 
     ELSE
@@ -2442,7 +2442,8 @@ IF (ukca_config%l_ukca_chem) THEN
            atm_mebr_mol,                                                       &
            atm_h2_mol,                                                         &
            H_plus_3d_arr,                                                      &
-           zdryrt, zwetrt, nlev_with_ddep,                  L_stratosphere,    &
+           zdryrt, zwetrt, nlev_with_ddep,                                     &
+           co2_interactive, L_stratosphere,                                    &
            l_firstchem                                                         &
            )
     END IF

--- a/src/control/core/top_level/ukca_main1-ukca_main1.F90
+++ b/src/control/core/top_level/ukca_main1-ukca_main1.F90
@@ -2368,7 +2368,7 @@ IF (ukca_config%l_ukca_chem) THEN
            atm_mebr_mol,                                                       &
            atm_h2_mol,                                                         &
            H_plus_3d_arr,                                                      &
-           zdryrt, zwetrt, nlev_with_ddep, L_stratosphere, co2_interactive,    &
+           zdryrt, zwetrt, nlev_with_ddep, L_stratosphere,                     &
            l_firstchem                                                         &
            )
 
@@ -2442,7 +2442,7 @@ IF (ukca_config%l_ukca_chem) THEN
            atm_mebr_mol,                                                       &
            atm_h2_mol,                                                         &
            H_plus_3d_arr,                                                      &
-           zdryrt, zwetrt, nlev_with_ddep, co2_interactive, L_stratosphere,    &
+           zdryrt, zwetrt, nlev_with_ddep,                  L_stratosphere,    &
            l_firstchem                                                         &
            )
     END IF

--- a/src/science/core/chemistry/ukca_chemistry_ctl.F90
+++ b/src/science/core/chemistry/ukca_chemistry_ctl.F90
@@ -61,7 +61,7 @@ SUBROUTINE ukca_chemistry_ctl(                                                 &
                 atm_mebr_mol,                                                  &
                 atm_h2_mol,                                                    &
                 H_plus,                                                        &
-                zdryrt, zwetrt, nlev_with_ddep,                                &
+                zdryrt, zwetrt, nlev_with_ddep, co2_interactive,               &
                 L_stratosphere, firstcall                                      &
                 )
 
@@ -88,7 +88,7 @@ USE ukca_constants,       ONLY: c_h2o, c_hono2, c_o1d, c_o3p, c_co2
 USE ukca_config_constants_mod, ONLY: avogadro
 USE ukca_config_specification_mod, ONLY: ukca_config
 USE ukca_ntp_mod,         ONLY: ntp_type, dim_ntp, name2ntpindex
-USE ukca_environment_fields_mod, ONLY: co2_interactive
+
 USE yomhook,              ONLY: lhook, dr_hook
 USE parkind1,             ONLY: jprb, jpim
 USE ereport_mod,          ONLY: ereport
@@ -119,6 +119,11 @@ REAL, INTENT(IN) :: so4_sa(tot_n_pnts)              ! aerosol surface area
 REAL, INTENT(IN) :: zdryrt(theta_field_size,jpdd)   ! dry dep rate
 REAL, INTENT(IN) :: zwetrt(tot_n_pnts,jpdw)         ! wet dep rate
 REAL, INTENT(IN) :: photol_rates(tot_n_pnts,jppj)
+
+! must be allocatable as passed unallocated from main if l_chem_environ_co2_fld
+! is false
+REAL, INTENT(IN), ALLOCATABLE :: co2_interactive(row_length,rows,model_levels)
+
 REAL, INTENT(OUT) :: shno3_3d(tot_n_pnts)
 REAL, INTENT(IN OUT) :: q(tot_n_pnts)               ! water vapour
 REAL, INTENT(IN OUT) :: tracer(tot_n_pnts,ntracers) ! tracer MMR
@@ -302,6 +307,7 @@ DO k=1,model_levels
   ! Put tracer mmr into 1-D array for use in ASAD chemical solver
   zq(:) = q(kcs:kce)/c_h2o
 
+  ! CO2 as species
   IF (ANY(speci(:) == 'CO2       ')) THEN
     !  Copy the CO2 concentration into the asad module as VMR
     IF (ukca_config%l_chem_environ_co2_fld) THEN
@@ -309,7 +315,7 @@ DO k=1,model_levels
       ! co2_interactive should be allocated if config option on
       IF (.NOT. ALLOCATED(co2_interactive)) THEN
         errcode = 1
-        CALL ereport(ModuleName//':'//RoutineName, errcode,                  &
+        CALL ereport(ModuleName//':'//RoutineName, errcode,                    &
           'ERROR: co2_interactive array not allocated')
       END IF
 
@@ -318,7 +324,7 @@ DO k=1,model_levels
       co2_1d(:) = rmdi
     END IF
 
-  END IF       ! CO2 as species
+  END IF
 
   ! Convert mmr into vmr for tracers. Pass data from the tracer 3D array,
   ! unwrap it and pass into the 1D zftr array before calling ASAD_CDRIVE.

--- a/src/science/core/chemistry/ukca_chemistry_ctl.F90
+++ b/src/science/core/chemistry/ukca_chemistry_ctl.F90
@@ -122,7 +122,7 @@ REAL, INTENT(IN) :: photol_rates(tot_n_pnts,jppj)
 
 ! must be allocatable as passed unallocated from main if l_chem_environ_co2_fld
 ! is false
-REAL, INTENT(IN), ALLOCATABLE :: co2_interactive(row_length,rows,model_levels)
+REAL, INTENT(IN), ALLOCATABLE :: co2_interactive(:,:,:)
 
 REAL, INTENT(OUT) :: shno3_3d(tot_n_pnts)
 REAL, INTENT(IN OUT) :: q(tot_n_pnts)               ! water vapour

--- a/src/science/core/chemistry/ukca_chemistry_ctl.F90
+++ b/src/science/core/chemistry/ukca_chemistry_ctl.F90
@@ -61,7 +61,7 @@ SUBROUTINE ukca_chemistry_ctl(                                                 &
                 atm_mebr_mol,                                                  &
                 atm_h2_mol,                                                    &
                 H_plus,                                                        &
-                zdryrt, zwetrt, nlev_with_ddep, co2_interactive,               &
+                zdryrt, zwetrt, nlev_with_ddep,                                &
                 L_stratosphere, firstcall                                      &
                 )
 
@@ -88,6 +88,7 @@ USE ukca_constants,       ONLY: c_h2o, c_hono2, c_o1d, c_o3p, c_co2
 USE ukca_config_constants_mod, ONLY: avogadro
 USE ukca_config_specification_mod, ONLY: ukca_config
 USE ukca_ntp_mod,         ONLY: ntp_type, dim_ntp, name2ntpindex
+USE ukca_environment_fields_mod, ONLY: co2_interactive
 USE yomhook,              ONLY: lhook, dr_hook
 USE parkind1,             ONLY: jprb, jpim
 USE ereport_mod,          ONLY: ereport
@@ -118,7 +119,6 @@ REAL, INTENT(IN) :: so4_sa(tot_n_pnts)              ! aerosol surface area
 REAL, INTENT(IN) :: zdryrt(theta_field_size,jpdd)   ! dry dep rate
 REAL, INTENT(IN) :: zwetrt(tot_n_pnts,jpdw)         ! wet dep rate
 REAL, INTENT(IN) :: photol_rates(tot_n_pnts,jppj)
-REAL, INTENT(IN) :: co2_interactive(tot_n_pnts)
 REAL, INTENT(OUT) :: shno3_3d(tot_n_pnts)
 REAL, INTENT(IN OUT) :: q(tot_n_pnts)               ! water vapour
 REAL, INTENT(IN OUT) :: tracer(tot_n_pnts,ntracers) ! tracer MMR
@@ -305,7 +305,15 @@ DO k=1,model_levels
   IF (ANY(speci(:) == 'CO2       ')) THEN
     !  Copy the CO2 concentration into the asad module as VMR
     IF (ukca_config%l_chem_environ_co2_fld) THEN
-      co2_1d(:) = co2_interactive(kcs:kce)/c_co2
+
+      ! co2_interactive should be allocated if config option on
+      IF (.NOT. ALLOCATED(co2_interactive)) THEN
+        errcode = 1
+        CALL ereport(ModuleName//':'//RoutineName, errcode,                  &
+          'ERROR: co2_interactive array not allocated')
+      END IF
+
+      co2_1d(:) = RESHAPE(co2_interactive(:,:,k), [theta_field_size]) / c_co2
     ELSE
       co2_1d(:) = rmdi
     END IF

--- a/src/science/core/chemistry/ukca_chemistry_ctl_col_mod.F90
+++ b/src/science/core/chemistry/ukca_chemistry_ctl_col_mod.F90
@@ -143,7 +143,7 @@ REAL, INTENT(IN) :: photol_rates(row_length,rows,model_levels,jppj)
 
 ! must be allocatable as passed unallocated from main if l_chem_environ_co2_fld
 ! is false
-REAL, INTENT(IN), ALLOCATABLE :: co2_interactive(row_length,rows,model_levels)
+REAL, INTENT(IN), ALLOCATABLE :: co2_interactive(:,:,:)
 
 REAL, INTENT(OUT)    :: shno3_3d(row_length,rows,model_levels)
 REAL, INTENT(IN OUT) :: q(row_length,rows,model_levels)  ! water vapour

--- a/src/science/core/chemistry/ukca_chemistry_ctl_col_mod.F90
+++ b/src/science/core/chemistry/ukca_chemistry_ctl_col_mod.F90
@@ -61,7 +61,7 @@ SUBROUTINE ukca_chemistry_ctl_col(                                             &
                 atm_mebr_mol,                                                  &
                 atm_h2_mol,                                                    &
                 H_plus_3d_arr,                                                 &
-                zdryrt, zwetrt, nlev_with_ddep                                 &
+                zdryrt, zwetrt, nlev_with_ddep, co2_interactive                &
                 )
 
 USE asad_mod,             ONLY: advt, cdt_diag, ctype,                         &
@@ -90,7 +90,6 @@ USE ukca_config_constants_mod, ONLY: avogadro
 USE ukca_config_specification_mod, ONLY: ukca_config
 
 USE ukca_ntp_mod,       ONLY: ntp_type, dim_ntp, name2ntpindex
-USE ukca_environment_fields_mod, ONLY: co2_interactive
 
 USE yomhook, ONLY: lhook, dr_hook
 USE parkind1, ONLY: jprb, jpim
@@ -141,6 +140,11 @@ REAL, INTENT(IN) :: so4_sa(row_length,rows,model_levels) ! aerosol surface area
 REAL, INTENT(IN) :: zdryrt(row_length,rows,jpdd)              ! dry dep rate
 REAL, INTENT(IN) :: zwetrt(row_length,rows,model_levels,jpdw) ! wet dep rate
 REAL, INTENT(IN) :: photol_rates(row_length,rows,model_levels,jppj)
+
+! must be allocatable as passed unallocated from main if l_chem_environ_co2_fld
+! is false
+REAL, INTENT(IN), ALLOCATABLE :: co2_interactive(row_length,rows,model_levels)
+
 REAL, INTENT(OUT)    :: shno3_3d(row_length,rows,model_levels)
 REAL, INTENT(IN OUT) :: q(row_length,rows,model_levels)  ! water vapour
 REAL, INTENT(IN OUT) :: tracer(row_length,rows,model_levels,                   &

--- a/src/science/core/chemistry/ukca_chemistry_ctl_col_mod.F90
+++ b/src/science/core/chemistry/ukca_chemistry_ctl_col_mod.F90
@@ -342,6 +342,14 @@ DO i=1,rows
     IF (ANY(speci(:) == 'CO2       ')) THEN
       ! Copy the CO2 concentration into the asad module as VMR
       IF (ukca_config%l_chem_environ_co2_fld) THEN
+
+        ! co2_interactive should be allocated if config option on
+        IF (.NOT. ALLOCATED(co2_interactive)) THEN
+          errcode = 1
+          CALL ereport(ModuleName//':'//RoutineName, errcode,                  &
+            'ERROR: co2_interactive array not allocated')
+        END IF
+
         co2_1d(:) = co2_interactive(j,i,:)/c_co2
       ELSE
         co2_1d(:) = rmdi

--- a/src/science/core/chemistry/ukca_chemistry_ctl_full_mod.F90
+++ b/src/science/core/chemistry/ukca_chemistry_ctl_full_mod.F90
@@ -62,7 +62,7 @@ SUBROUTINE ukca_chemistry_ctl_full(                                            &
                 atm_h2_mol,                                                    &
                 H_plus,                                                        &
                 zdryrt, zwetrt, nlev_with_ddep, L_stratosphere,                &
-                co2_interactive, firstcall                                     &
+                firstcall                                                      &
                 )
 
 USE asad_mod,             ONLY: advt, cdt_diag, ctype,                         &
@@ -89,6 +89,7 @@ USE ukca_constants,       ONLY: c_h2o, c_hono2, c_o1d, c_o3p, c_co2
 USE ukca_config_constants_mod, ONLY: avogadro
 USE ukca_config_specification_mod, ONLY: ukca_config
 USE ukca_ntp_mod,         ONLY: ntp_type, dim_ntp, name2ntpindex
+USE ukca_environment_fields_mod, ONLY: co2_interactive
 
 USE yomhook,              ONLY: lhook, dr_hook
 USE parkind1,             ONLY: jprb, jpim
@@ -122,7 +123,6 @@ REAL, INTENT(IN) :: so4_sa(tot_n_pnts)              ! aerosol surface area
 REAL, INTENT(IN) :: zdryrt(theta_field_size,jpdd)   ! dry dep rate
 REAL, INTENT(IN) :: zwetrt(tot_n_pnts,jpdw)         ! wet dep rate
 REAL, INTENT(IN) :: photol_rates(tot_n_pnts,jppj)
-REAL, INTENT(IN) :: co2_interactive(tot_n_pnts)
 REAL, INTENT(OUT) :: shno3(tot_n_pnts)
 REAL, INTENT(IN OUT) :: q(tot_n_pnts)               ! water vapour
 REAL, INTENT(IN OUT) :: tracer(tot_n_pnts,ntracers) ! tracer MMR
@@ -248,7 +248,15 @@ END IF
 IF (ANY(speci(:) == 'CO2       ')) THEN
   !  Copy the CO2 concentration into the asad module as VMR
   IF (ukca_config%l_chem_environ_co2_fld) THEN
-    co2_1d(:) = co2_interactive(:)/c_co2
+
+    ! co2_interactive should be allocated if config option on
+    IF (.NOT. ALLOCATED(co2_interactive)) THEN
+      errcode = 1
+      CALL ereport(ModuleName//':'//RoutineName, errcode,                      &
+        'ERROR: co2_interactive array not allocated')
+    END IF
+
+    co2_1d(:) = RESHAPE(co2_interactive, [tot_n_pnts]) / c_co2
   ELSE
     co2_1d(:) = rmdi
   END IF

--- a/src/science/core/chemistry/ukca_chemistry_ctl_full_mod.F90
+++ b/src/science/core/chemistry/ukca_chemistry_ctl_full_mod.F90
@@ -62,7 +62,7 @@ SUBROUTINE ukca_chemistry_ctl_full(                                            &
                 atm_h2_mol,                                                    &
                 H_plus,                                                        &
                 zdryrt, zwetrt, nlev_with_ddep, L_stratosphere,                &
-                firstcall                                                      &
+                co2_interactive, firstcall                                     &
                 )
 
 USE asad_mod,             ONLY: advt, cdt_diag, ctype,                         &
@@ -89,7 +89,6 @@ USE ukca_constants,       ONLY: c_h2o, c_hono2, c_o1d, c_o3p, c_co2
 USE ukca_config_constants_mod, ONLY: avogadro
 USE ukca_config_specification_mod, ONLY: ukca_config
 USE ukca_ntp_mod,         ONLY: ntp_type, dim_ntp, name2ntpindex
-USE ukca_environment_fields_mod, ONLY: co2_interactive
 
 USE yomhook,              ONLY: lhook, dr_hook
 USE parkind1,             ONLY: jprb, jpim
@@ -123,6 +122,11 @@ REAL, INTENT(IN) :: so4_sa(tot_n_pnts)              ! aerosol surface area
 REAL, INTENT(IN) :: zdryrt(theta_field_size,jpdd)   ! dry dep rate
 REAL, INTENT(IN) :: zwetrt(tot_n_pnts,jpdw)         ! wet dep rate
 REAL, INTENT(IN) :: photol_rates(tot_n_pnts,jppj)
+
+! must be allocatable as passed unallocated from main if l_chem_environ_co2_fld
+! is false
+REAL, INTENT(IN), ALLOCATABLE :: co2_interactive(row_length,rows,model_levels)
+
 REAL, INTENT(OUT) :: shno3(tot_n_pnts)
 REAL, INTENT(IN OUT) :: q(tot_n_pnts)               ! water vapour
 REAL, INTENT(IN OUT) :: tracer(tot_n_pnts,ntracers) ! tracer MMR
@@ -245,6 +249,7 @@ ELSE
   zprt1d(:,:) = photol_rates(:,:)
 END IF
 
+! CO2 as species
 IF (ANY(speci(:) == 'CO2       ')) THEN
   !  Copy the CO2 concentration into the asad module as VMR
   IF (ukca_config%l_chem_environ_co2_fld) THEN
@@ -260,7 +265,7 @@ IF (ANY(speci(:) == 'CO2       ')) THEN
   ELSE
     co2_1d(:) = rmdi
   END IF
-END IF       ! CO2 as species
+END IF
 
 ! Retrieve tropospheric heterogeneous rates from previous time step
 IF (ukca_config%l_ukca_trophet) THEN

--- a/src/science/core/chemistry/ukca_chemistry_ctl_full_mod.F90
+++ b/src/science/core/chemistry/ukca_chemistry_ctl_full_mod.F90
@@ -125,7 +125,7 @@ REAL, INTENT(IN) :: photol_rates(tot_n_pnts,jppj)
 
 ! must be allocatable as passed unallocated from main if l_chem_environ_co2_fld
 ! is false
-REAL, INTENT(IN), ALLOCATABLE :: co2_interactive(row_length,rows,model_levels)
+REAL, INTENT(IN), ALLOCATABLE :: co2_interactive(:,:,:)
 
 REAL, INTENT(OUT) :: shno3(tot_n_pnts)
 REAL, INTENT(IN OUT) :: q(tot_n_pnts)               ! water vapour


### PR DESCRIPTION
# PR Summary

Fixes #35 

Sci/Tech Reviewer: @mcdalvi <!-- SR id, filled by author when ready for review (e.g. @octocat) -->
Code Reviewer: @t00sa 

<!-- To be completed by the developer -->

<!-- Provide a brief description of the changes in this PR, including any notes
     useful for reviewers -->

so the CO2 environmental field is held in a co2_interactive variable 

```
REAL, ALLOCATABLE, TARGET, SAVE, PUBLIC :: co2_interactive(:,:,:)
  ! mass_fraction_of_carbon_dioxide_in_air [CF] {UM:00252}
```

CO2 is only added to fld_names if ukca_config%l_chem_environ_co2_fld

```
! CO2 field is required if option to use an external CO2 field is set
IF (ukca_config%l_chem_environ_co2_fld .AND. ANY(speci(:) == 'CO2       ')) THEN
  n = n + 1
  IF (n <= n_max) fld_names(n) = fldname_co2_interactive
END IF
```

It is then allocated 

```
CASE (fldname_co2_interactive)
  CALL set_field_3d_real(i_field, i1, i2, j1, j2, k1, k2, field_data,          &
                         co2_interactive)
```

But then in `ukca_main1` it is passed in unconditionally into `ukca_chemistry_ctl` and `ukca_chemistry_ctl_full` as an input variable. Inside both ctl files it has the following intent:

```
REAL, INTENT(IN) :: co2_interactive(tot_n_pnts)
```

so it is an explicit shaped array dummy variable - which needs to have been allocated. 

Fortran standards:
- An unallocated allocatable variable does **not** represent an array object.
- A non-allocatable dummy argument requires an actual argument that is an object of the appropriate type, rank, etc.
- Therefore, an unallocated allocatable cannot be associated with a non-allocatable dummy.

However some compilers consider it fine and others don't - seems like GNU in particular doesn't allow it. 

<!-- List any linked PRs here
- linked MetOffice/<REPO-NAME>#<pr-number>
-->

<!-- List any blocking PRs or issues to be closed here
- is blocked-by #pr-number
- blocks #pr-number
- closes #issue-number
- fixes #issue-number
- is related to #issue-number
-->

## Code Quality Checklist

(_Some checks are automatically carried out via the CI pipeline_)

- [x] I have performed a self-review of my own code
- [x] My code follows the project's style guidelines
- [x] Comments have been included that aid undertanding and enhance the
      readability of the code
- [x] My changes generate no new warnings

## Testing

- [ ] I have tested this change locally, using the UKCA rose-stem suite
- [ ] If shared files have been modified, I have run the UM and LFRic Apps rose
      stem suites
- [ ] If any tests fail (rose-stem or CI) the reason is understood and
      acceptable (eg. kgo changes)
- [ ] I have added tests to cover new functionality as appropriate (eg. system
      tests, unit tests, etc.)

<!-- Describe other testing performed (if applicable) -->

### trac.log

# Test Suite Results - lfric_apps - co2_interactive_testing/run2
 
## Suite Information
 
| Item | Value |
| :--- | :--- |
| Suite Name | [co2_interactive_testing/run2](https://cylchub/services/cylc-review/cycles/robert.waters/?suite=co2_interactive_testing%2Frun2) |
| Suite User | robert.waters |
| Workflow Start | 2026-07-27T15:01:48 |
| Groups Run | all |
 
| Dependency | Reference | Main Like |
| :--- | :--- | :--- |
| casim | [MetOffice/casim@2026.07.1](https://github.com/MetOffice/casim/tree/2026.07.1) | True |
| jules | [MetOffice/jules@2026.07.1](https://github.com/MetOffice/jules/tree/2026.07.1) | True |
| lfric_apps | [RobWatersMet/lfric_apps@co2_interactive_testing](https://github.com/RobWatersMet/lfric_apps/tree/co2_interactive_testing) | False |
| lfric_core | [MetOffice/lfric_core@2026.07.1](https://github.com/MetOffice/lfric_core/tree/2026.07.1) | True |
| moci | [MetOffice/moci@2026.07.1](https://github.com/MetOffice/moci/tree/2026.07.1) | True |
| SimSys_Scripts | [MetOffice/SimSys_Scripts@2026.07.1](https://github.com/MetOffice/SimSys_Scripts/tree/2026.07.1) | True |
| socrates | [MetOffice/socrates@2026.07.1](https://github.com/MetOffice/socrates/tree/2026.07.1) | True |
| socrates-spectral | [MetOffice/socrates-spectral@2026.07.1](https://github.com/MetOffice/socrates-spectral/tree/2026.07.1) | True |
| ukca | [RobWatersMet/ukca@issue_35_co2_interactive](https://github.com/RobWatersMet/ukca/tree/issue_35_co2_interactive) | True |
 
## Task Information
:white_check_mark: succeeded tasks - 1602

# Test Suite Results - um - co2_interactive_testing_um/run2
 
## Suite Information
 
| Item | Value |
| :--- | :--- |
| Suite Name | [co2_interactive_testing_um/run2](https://cylchub/services/cylc-review/cycles/robert.waters/?suite=co2_interactive_testing_um%2Frun2) |
| Suite User | robert.waters |
| Workflow Start | 2026-07-29T10:15:48 |
| Groups Run | all |
 
| Dependency | Reference | Main Like |
| :--- | :--- | :--- |
| casim | [MetOffice/casim@2026.07.1](https://github.com/MetOffice/casim/tree/2026.07.1) | True |
| jules | [MetOffice/jules@2026.07.1](https://github.com/MetOffice/jules/tree/2026.07.1) | True |
| moci | [MetOffice/moci@2026.07.1](https://github.com/MetOffice/moci/tree/2026.07.1) | True |
| mule | [MetOffice/mule@2026.07.1](https://github.com/MetOffice/mule/tree/2026.07.1) | True |
| shumlib | [MetOffice/shumlib@2026.07.1](https://github.com/MetOffice/shumlib/tree/2026.07.1) | True |
| socrates | [MetOffice/socrates@2026.07.1](https://github.com/MetOffice/socrates/tree/2026.07.1) | True |
| SimSys_Scripts | [MetOffice/SimSys_Scripts@2026.07.1](https://github.com/MetOffice/SimSys_Scripts/tree/2026.07.1) | True |
| ukca | [RobWatersMet/ukca@issue_35_co2_interactive](https://github.com/RobWatersMet/ukca/tree/issue_35_co2_interactive) | True |
| um | [RobWatersMet/um@co2_interactive_testing](https://github.com/RobWatersMet/um/tree/co2_interactive_testing) | False |
| um_aux | [MetOffice/um_aux@2026.07.1](https://github.com/MetOffice/um_aux/tree/2026.07.1) | True |
| um_meta | [MetOffice/um_meta@2026.07.1](https://github.com/MetOffice/um_meta/tree/2026.07.1) | True |
 
## Approvals
### Code Owners
Luke Abraham - approved
### Config Owners
No UM Config Owners Required
## Task Information
:white_check_mark: succeeded tasks - 2770


## Security Considerations

- [x] I have reviewed my changes for potential security issues
- [x] Sensitive data is properly handled (if applicable)
- [x] Authentication and authorisation are properly implemented (if applicable)

## Performance Impact

- [x] Performance of the code has been considered and, if applicable, suitable
      performance measurements have been conducted

## AI Assistance and Attribution

- [ ] Some of the content of this change has been produced with the assistance
      of _Generative AI tool name_ (e.g., Met Office Github Copilot Enterprise,
      Github Copilot Personal, ChatGPT GPT-4, etc) and I have followed the
      [Simulation Systems AI policy](https://metoffice.github.io/simulation-systems/FurtherDetails/ai.html)
      (including attribution labels)

<!-- If AI has been used, please provide more details here -->

## Documentation

- [x] Where appropriate I have updated documentation related to this change and
      confirmed that it builds correctly

# Sci/Tech Review

<!-- To be completed by the Sci/Tech Reviewer -->
<!-- May be skipped for trivial tickets -->

- [X] I understand this area of code and the changes being added
- [X] The proposed changes correspond to the pull request description
- [X] Documentation is sufficient (do documentation papers need updating)
- [X] Sufficient testing has been completed (Both UM and LFRic)

_Please alert the code reviewer via a tag when you have approved the SR_

# Code Review

<!-- To be completed by the Code Reviewer -->

- [ ] All dependencies have been resolved
- [ ] Related Issues have been properly linked and addressed
- [ ] CLA compliance has been confirmed
- [ ] Code quality standards have been met
- [ ] Tests are adequate and have passed
- [ ] Documentation is complete and accurate
- [ ] Security considerations have been addressed
- [ ] Performance impact is acceptable
